### PR TITLE
ci: use Github Actions in parallel to Travis CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+---
+name: ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+  - cron: '35 4 * * 4'  # weekly on thursday morning
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version:
+        - '2.5'
+        - '2.6'
+        - '2.7'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Install dependencies
+      run: |
+        bundle
+    - name: Test
+      run: |
+        bundle exec rake ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ services:
 - docker
 
 script:
-- bundle exec rake travis
+- bundle exec rake ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 3.1.1 (october 3, 2020)
+## 3.1.2
+
+OTHER:
+
+- start using Github Actions CI for tests in addition to Travis CI
+
+## 3.1.1 (October 3, 2020)
 
 IMPROVEMENTS:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dyndnsd.rb
 
-[![Build Status](https://travis-ci.com/cmur2/dyndnsd.svg?branch=master)](https://travis-ci.com/cmur2/dyndnsd) [![Dependencies](https://badges.depfu.com/badges/4f25da8493f7a29f652ac892fbf9227b/overview.svg)](https://depfu.com/github/cmur2/dyndnsd)
+[![Build Status](https://travis-ci.com/cmur2/dyndnsd.svg?branch=master)](https://travis-ci.com/cmur2/dyndnsd) ![ci](https://github.com/cmur2/dyndnsd/workflows/ci/badge.svg) [![Dependencies](https://badges.depfu.com/badges/4f25da8493f7a29f652ac892fbf9227b/overview.svg)](https://depfu.com/github/cmur2/dyndnsd)
 
 A small, lightweight and extensible DynDNS server written with Ruby and Rack.
 

--- a/Rakefile
+++ b/Rakefile
@@ -28,4 +28,4 @@ end
 
 task default: [:rubocop, :spec, 'bundle:audit', :solargraph]
 
-task travis: ['solargraph:init', :default, :hadolint]
+task ci: ['solargraph:init', :default, :hadolint]


### PR DESCRIPTION
- this adds a new workflow for Github Actions that mirrors what the existing Travis CI workflow tests
- Travis CI might become unfriendly to opensource soonish so migration might be necessary