### PR TITLE
ci: use GHA ruby/setup-ruby instead of broken actions/setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby-version }}
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Install dependencies


### PR DESCRIPTION
- actions/setup-ruby does not work on new GHA runners Ubuntu 20.04 (missing bundler in 2.5) as per actions/setup-ruby#70
- might be deprecated as per actions/setup-ruby#80
- https://github.com/ruby/setup-ruby is recommended is superior