### PR TITLE
Migrate from OpenTracing to OpenTelemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,9 +271,9 @@ users:
 
 ### Tracing (experimental)
 
-For tracing, dyndnsd.rb is instrumented using the [OpenTracing](http://opentracing.io/) framework and will emit span tracing data for the most important operations happening during the request/response cycle. Using a middleware for Rack allows handling incoming OpenTracing span information properly.
+For tracing, dyndnsd.rb is instrumented using the [OpenTelemetry](https://opentelemetry.io/docs/ruby/) framework and will emit span tracing data for the most important operations happening during the request/response cycle. Using an [instrumentation for Rack](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation/rack) allows handling incoming OpenTelemetry parent span information properly (when desired, turned off by default to reduce attack surface).
 
-Currently, only one OpenTracing-compatible tracer implementation named [CNCF Jaeger](https://github.com/jaegertracing/jaeger) can be configured to use with dyndnsd.rb.
+Currently, the [OpenTelemetry trace exporter](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/jaeger) for [CNCF Jaeger](https://github.com/jaegertracing/jaeger) can be enabled via dyndnsd.rb configuration. Alternatively, you can also enable other exporters via the environment variable `OTEL_TRACES_EXPORTER`, e.g. `OTEL_TRACES_EXPORTER=console`.
 
 ```yaml
 host: "0.0.0.0"
@@ -282,11 +282,9 @@ db: "/opt/dyndnsd/db.json"
 domain: "dyn.example.org"
 # enable and configure tracing using the (currently only) tracer jaeger
 tracing:
-  trust_incoming_span: false # default value, change to accept incoming OpenTracing spans as parents
-  jaeger:
-    host: 127.0.0.1 # defaults for host and port of local jaeger-agent
-    port: 6831
-    service_name: "my.dyndnsd.identifier"
+  trust_incoming_span: false # default value, change to accept incoming OpenTelemetry spans as parents
+  service_name: "my.dyndnsd.identifier" # default unset, will be populated by OpenTelemetry
+  jaeger: true # enables the Jaeger AgentExporter
 # configure the updater, here we use command_with_bind_zone, params are updater-specific
 updater:
   name: "command_with_bind_zone"

--- a/dyndnsd.gemspec
+++ b/dyndnsd.gemspec
@@ -28,11 +28,11 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5'
 
   s.add_runtime_dependency 'async-dns', '~> 1.2.0'
-  s.add_runtime_dependency 'jaeger-client', '~> 1.1.0'
   s.add_runtime_dependency 'metriks'
-  s.add_runtime_dependency 'opentracing', '~> 0.5.0'
+  s.add_runtime_dependency 'opentelemetry-exporter-jaeger', '~> 0.18.0'
+  s.add_runtime_dependency 'opentelemetry-instrumentation-rack', '~> 0.18.0'
+  s.add_runtime_dependency 'opentelemetry-sdk', '~> 1.0.0.rc1'
   s.add_runtime_dependency 'rack', '~> 2.0'
-  s.add_runtime_dependency 'rack-tracer', '~> 0.9.0'
   s.add_runtime_dependency 'webrick', '>= 1.6.1'
 
   s.add_development_dependency 'bundler'

--- a/lib/dyndnsd/updater/command_with_bind_zone.rb
+++ b/lib/dyndnsd/updater/command_with_bind_zone.rb
@@ -18,7 +18,7 @@ module Dyndnsd
         return if !db.changed?
 
         Helper.span('updater_update') do |span|
-          span.set_tag('dyndnsd.updater.name', self.class.name&.split('::')&.last || 'None')
+          span.set_attribute('dyndnsd.updater.name', self.class.name&.split('::')&.last || 'None')
 
           # write zone file in bind syntax
           File.open(@zone_file, 'w') { |f| f.write(@generator.generate(db)) }

--- a/lib/dyndnsd/updater/zone_transfer_server.rb
+++ b/lib/dyndnsd/updater/zone_transfer_server.rb
@@ -35,7 +35,7 @@ module Dyndnsd
       # @return [void]
       def update(db)
         Helper.span('updater_update') do |span|
-          span.set_tag('dyndnsd.updater.name', self.class.name&.split('::')&.last || 'None')
+          span.set_attribute('dyndnsd.updater.name', self.class.name&.split('::')&.last || 'None')
 
           soa_rr = Resolv::DNS::Resource::IN::SOA.new(
             @zone_nameservers[0], @zone_email_address,

--- a/spec/dyndnsd/daemon_spec.rb
+++ b/spec/dyndnsd/daemon_spec.rb
@@ -24,9 +24,7 @@ describe Dyndnsd::Daemon do
 
     app = Rack::Auth::Basic.new(daemon, 'DynDNS', &daemon.method(:authorized?))
 
-    app = Dyndnsd::Responder::DynDNSStyle.new(app)
-
-    Rack::Tracer.new(app, trust_incoming_span: false)
+    Dyndnsd::Responder::DynDNSStyle.new(app)
   end
 
   it 'requires authentication' do


### PR DESCRIPTION
R.I.P. https://opentracing.io/

Using https://github.com/open-telemetry/opentelemetry-ruby which offers SDK, Rack middleware and Jaeger exporter should be usable as drop-in replacement.